### PR TITLE
add -DNO_MKLINK=1 flag for cmake to force copying files to the VST3 f…

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ examples:
 	cmake.exe -G "Visual Studio 15 2017" -A Win32 ../vst3sdk
 </pre>
 
+- add the `-DNO_MKLINK=1` argument to cmake.exe if you don't have permission to execute mklink.
 - Now you can build the plug-in (you can use Visual Studio too):
 
 <pre>


### PR DESCRIPTION
…older in order to avoid mklink permission issues